### PR TITLE
Made some changes the locator and states' sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -689,36 +689,16 @@
         <h1>States of a Portable Web Publication</h1>
 
         <p>
-            During the consumption of a publication, a user may change the state of their PWP.
-            The <dfn data-lt="state">states</dfn> of a PWP can be separated into two different axes.
-            These different states require a different behavior from the user agent, while some of the characteristics of the publication may be invariant across states.
-            The different states are as follows:
+            During the consumption of a publication, a user may change the “state” of their PWP.
+            The states of a PWP reflects whether the document is online or offline, or whether it is packed (i.e., all constituents are packged in a, say, ZIP file) or not. These different states require a different behavior from the user agent, while some of the characteristics of the publication may be invariant across states. The table below shows the same publication (PWP) in the most typical states:
         </p>
-
-        <ol class="definition">
-            <li><strong>States related to the organization of the <a data-lt="Web Resource">Web Resources</a></strong>: A <a>Portable Web Publication</a> is in
-                <ul>
-                    <li><dfn data-lt="Packed">Packed State</dfn>: when all constituent <a data-lt="Web Resource">Web Resources</a> are combined into one unit for storage in a file system, network transfer, etc.</li>
-                    <li><dfn data-lt="Unpacked">Unpacked State</dfn>: when all constituent <a data-lt="Web Resource">Web Resources</a> can be directly accessed individually.</li>
-                </ul>
-            </li>
-
-            <li><strong>States related to the access of <a data-lt="Web Resource">Web Resources</a></strong>: A <a>Portable Web Publication</a> is in
-                <ul>
-                    <li><dfn data-lt="Protocol">Protocol State</dfn>: when all constituent <a data-lt="Web Resource">Web Resources</a>, as well as the <a>Portable Web Publication</a> itself, are accessed through network protocols like HTTP, HTTPS, or FTP</li>
-                    <li><dfn data-lt="File">File State</dfn>: when all constituent <a data-lt="Web Resource">Web Resources</a>, as well as the <a>Portable Web Publication</a> itself, are accessed as files on a local file system</li>
-                </ul>
-            </li>
-        </ol>
-
-        <p>The table below shows the same publication (PWP) in the most typical states:</p>
 
         <table class="zebra">
             <tbody>
             <tr>
                 <th></th>
-                <th>Protocol</th>
-                <th>File</th>
+                <th>Online</th>
+                <th>Offline</th>
             </tr>
             <tr>
                 <th>Packed</th>
@@ -734,12 +714,10 @@
         </table>
 
         <aside class="note">
-            The difference between <a>protocol</a> and <a>file</a> states is not identical, although close, to the difference between the commonly used notions of “online” vs. “offline”.
-            A PWP can be on a local disc but accessed through a Web Server running on that machine (i.e., through a <code>http://localhost</code> URL): the PWP is in a <a>protocol</a> state, though clearly “offline”.
-            Similarly, a remote file system can be mounted as a local disc, in which case a PWP can be accessed as a file, i.e., is in a <a>file</a> state, though possibly “online”.
+            The terms “online” and “offline” are used in this document, but the borderline between these is not always clear cut. For example, a PWP can be on a local disc but accessed through a Web Server running on that machine (i.e., through a <code>http://localhost</code> URL): the behaviour of the client is identical to the situation when the publication is genuinely online, although, technically, the publication is clearly offline. Similarly, a remote file system can be mounted as a local disc, in which case a PWP can be accessed as a file though technically online. A more precise terminology would use the terms like “protocol” and “file” states, for what is colloquially called “online” and “offline” in this document.
         </aside>
 
-        <p>This is related to <a href="#fundamental-online-offline"></a>, <a href="#fundamental-transition"></a> and <a href="#non-essential-resources"></a>.</p>
+        <p>The concept of states is related to <a href="#fundamental-online-offline"></a>, <a href="#fundamental-transition"></a> and <a href="#non-essential-resources"></a>.</p>
 
         <ul class="use-cases">
             <li>A user starts reading on an internet enabled PC, move to an internet-enabled portable device, which may enter offline-mode at some point, and then finish up on another PC.</li>
@@ -935,45 +913,46 @@
 </section>
 
 <section>
-    <h1>Locating the Same Publication Across States</h1>
-
-    <p>
-        A user reads a publication across states. When providing a pointer to (a part of) a publication, this should be robust across states.
-        Locating a resource within a PWP should not depend on the PWP's state.
-    </p>
-
-    <p class="note">
-        This is related to <a href="https://www.w3.org/TR/dpub-annotation-uc/#cross-format-annotations">https://www.w3.org/TR/dpub-annotation-uc/#cross-format-annotations</a> and <a href="https://www.w3.org/TR/dpub-annotation-uc/#cross-version-annotations">https://www.w3.org/TR/dpub-annotation-uc/#cross-version-annotations</a>.
-    </p>
-
-    <ul class="use-cases">
-        <li>
-            Writer Annie has her book published on her own web space as a PWP.
-            Reader Bob opens it online using a dedicated PWP reader, and highlights a nice quote.
-            When Bob reads the same book later on, the highlight is retrieved, whether the PWP is opened using the same PWP reader, opened in a browser, downloaded locally, etc.
-        </li>
-        <li>
-            Annie sends Bob the state-independent locator to the second chapter of ‘Moby Dick’ while reading it online.
-            Bob can use that state-independent locator for his own copy of ‘Moby Dick’, even though it is loaded from a local package.
-        </li>
-    </ul>
-
-    <p class="note">
-        Highlights are in this case <a href="http://w3c.github.io/web-annotation/">Web Annotations</a>, i.e., stored online, with links to the highlighted text.
-    </p>
+    <h2>Locators</h2>
 
     <section>
-        <h3>State-Independent Locator vs. State-Dependent Locators</h3>
+        <h1>Locating the Same Publication Across States</h1>
 
         <p>
-            To be able to connect the same publication across status, there needs to be a common, state-independent locator.
+            A user reads a publication across states. When providing a pointer to (a part of) a publication, this should be robust across states. Locating a resource within a PWP should not depend on the PWP's state.
         </p>
 
-        <ul class="requirements">
-            <li>This state-independent locator (also known as the canonical locator, https://tools.ietf.org/html/rfc6596) should be part of the PWP.</li>
-            <li>There MUST be a separation between a format-independent (“canonical”) and format-dependent locator.</li>
-            <li>It MUST be possible (and necessary) to use, for all cross-references, the canonical locator.</li>
+        <p>
+            Some use cases, documented separately&nbsp;[[dpub-annotation-uc]] for the purpose of annotations, imply this issue:
+        </p>
+
+        <ul>
+            <li><a href="https://www.w3.org/TR/dpub-annotation-uc/#cross-format-annotations">2.3.1. Cross Format annotations</a></li>
+            <li><a href="https://www.w3.org/TR/dpub-annotation-uc/#cross-version-annotations">2.3.2. Cross Version annotations</a></li>
         </ul>
+
+        <ul class="use-cases">
+            <li>
+                Writer Annie has her book published on her own web space as a PWP.
+                Reader Bob opens it online using a dedicated PWP reader, and highlights a nice quote.
+                When Bob reads the same book later on, the highlight is retrieved, whether the PWP is opened using the same PWP reader, opened in a browser, downloaded locally, etc.
+            </li>
+            <li>
+                Annie sends Bob the state-independent locator to the second chapter of ‘Moby Dick’ while reading it online.
+                Bob can use that state-independent locator for his own copy of ‘Moby Dick’, even though it is loaded from a local package.
+            </li>
+        </ul>
+
+        <p class="note">
+            Highlights are, in this case, Web Annotations&nbsp;[[annotation-model]], i.e., stored online with links to the highlighted text.
+        </p>
+    </section>
+
+    <section>
+        <h3>State-Independent vs. State-Dependent Locators</h3>
+        <p>
+            To be able to connect the same publication across status, there needs to be a common, state-independent locator. This state-independent locator (also known as the canonical locator&nbsp;[[rfc6596]] should be part of the PWP. There MUST be a separation between a format-independent (“canonical”) and format-dependent locator and it MUST be possible (and necessary) to use, for all cross-references, the canonical locator.
+        </p>
 
         <ul class="use-cases">
             <li>
@@ -987,19 +966,14 @@
     <section>
         <h3>Relative Locators</h3>
 
-        <p>Relative locators are abundant on the Web. State-independent locators should not break this mechanism.</p>
-
-        <ul class="requirements">
-            <li>It SHOULD be possible to use, in all circumstances, a relative locator to refer to content in a PWP.</li>
-            <li>A PWP Processor MUST be able to combine a relative locator with the canonical as well as state dependent locators of a PWP.</li>
-        </ul>
+        <p>Relative locators are abundant on the Web. State-independent locators should not break this mechanism. It SHOULD be possible to use, in all circumstances, a relative locator to refer to content within a PWP. A PWP Processor MUST be able to combine a relative locator with the canonical as well as state dependent locators of a PWP.</p>
 
         <ul class="use-cases">
             <li>
                 Nick creates his own short story.
                 Based on choices of the reader, the story is different (e.g.: `If you want to go into the rabbit hole, see <a href="#">chapter 3</a>, otherwise, see <a href="#">chapter 4</a>`).
                 He publishes this PWP online with relative links between the different chapters.
-                When Annie downloads this publication as a package, all the relative links still work as expected.
+                When Annie downloads this publication as a package, all the relative links still work as expected, regardless of the state the publication is in when Annie reads it.
             </li>
         </ul>
     </section>
@@ -1023,21 +997,19 @@
 
     <section>
         <h3>Identifiers</h3>
-
         <p>
-            Identification of a publication is orthogonal to the issue at hand.
-            This document does not address the unique identification of a PWP, but does address the requirements that any such identifier is usable across states and does not conflict with locators.
+            Identification of a publication is orthogonal to the issue of locators. There are no specific requirements on identification of PWP-s in this document in general; however, any such identifier MUST be usable across states and MUST NOT conflict with locators. There needs to be persistence of identifiers across PWP instances.
         </p>
 
-        <ul class="requirements">
-            <li>
-                There needs to be persistence of identifiers across PWP instances.
-                (However, this does not imply that the same PWP in different states is required to use the same identifier)
-            </li>
+        <aside class="note">
+            This does not imply that the same PWP in different states is required to use the same identifier.
+        </aside>
+
+        <ul class="use-cases">
+            <li>Zoltán publishes a scholarly article in PWP format. The publisher assigns a <a href="http://www.doi.org/">DOI</a> to the publication, which becomes its unique identifier. Zoltán’s colleague, Sean, downloads a copy of the article to his own user space; the copy receives a new locator corresponding to Sean’s Web space. However, the paper’s DOI remains unchanged, and is to be used as an unambiguous reference by Sean.</li>
         </ul>
     </section>
 </section>
-
 
 <section>
   <h1>Archiving</h1>


### PR DESCRIPTION
- change in the locators' section
  - put all locators' subsection into one, to-level section
  - stylistic changes in the locator section , trying to unify it with the rest of the document:
    - section heading is followed by a paragraph detailing the requirement, that is followed by the use cases
    - bullet section is usually not used elsewhere to list the requirement
  - Added a use case for the unique identifier section
- Simplified the definition for states
  - Made it a bit less formal
  - Removed state dfn references (They led to a number of respec errors...)
