### PR TITLE
Bringing Discoverability and Metadata up to the Fundamental requirements section.

### DIFF
--- a/index.html
+++ b/index.html
@@ -506,6 +506,14 @@
                         easier to sleep when she puts the PWP aside.</li>
                     </ul>
                   </section>
+                  <section>
+                      <h3>The publication must be discoverable</h3>
+                      Before potentually purchasing and downloading a book, a user during the discovery phase will want to determin if this book has the appropriate features they are looking for.
+                        <ul class="use-cases">
+                            <li><a href="#accessible-metadata"></a></li>
+                            <li>Frank is a ornithologist looking for a publicaton which includes audio tracks of bird calls.</li>
+                        </ul>
+                  </section>
 
                   <section id="versioning">
                      <h3>There should be a way to control versioning and revisioning</h3>
@@ -1082,7 +1090,7 @@
         <li><a href="#single-package"></a></li>
     </ul>
 
-    <section>
+    <section id="accessible-metadata">
     <h2>Accessible Metadata</h2>
     <p> Accessibility of a PWP as a whole must be discoverable so that users know how (or whether) a PWP is accessible. See also <a href="#technical-metadata"></a></p>
     <ul class="use-cases">

--- a/index.html
+++ b/index.html
@@ -1097,6 +1097,7 @@
       <li> Accessibility of a PWP must be discoverable so that users know how (or whether) a PWP is accessible</li>
         <li>Ferdous wants to buy a book about a museum exhibit and wants to guarantee before he does that his screen reader will describe the images to him in great detail.</li>
         <li>Alejandra must ensure that the equation editors in her textbook have non-mouse functionality before she purchases the textbook.</li>
+        <li>A university professor is developing a course and the professor knows that he is required to use accessible digital materials. The professor uses the search capabilities of available publications to determine which titles are accessible and therefore suitable for his use.</li>
     </ul>
     <p>Granular Accessibility of a PWP must be discoverable so that users know how (or whether) a specific chapter or element within a PWP is accessible</p>
     <ul class="use-cases">


### PR DESCRIPTION
Discoverability is a fundamental requirement for PWP.  We need to ensure that persons with disabilities can find the correct publication that will be consumable.  This also has a more widespread use case as well which is why we need to call it out in section 2.
