### PR TITLE
Erroneous uses of Portable Web Publication

### DIFF
--- a/index.html
+++ b/index.html
@@ -1213,7 +1213,7 @@ A Web Publication should encompass publications such as audiobooks, graphic book
       <section id="check-origin">
         <h2>Authenticity</h2>
         <p class="req-set" id="r_check_origin">
-          The publisher should be able to provide information in a Portable Web Publication that can be used to check
+          The publisher should be able to provide information in a Packaged Web Publication that can be used to check
           the origin of the publication and its authenticity.
         </p>
         <ul class="use-cases">
@@ -1229,7 +1229,7 @@ A Web Publication should encompass publications such as audiobooks, graphic book
       <section id="integrity">
         <h2>Integrity</h2>
         <p class="req-set" id="r_check_integrity">
-          The publisher should be able to provide information in a Portable Web Publication proving that the
+          The publisher should be able to provide information in a Packaged Web Publication proving that the
           publication has not been tampered with during delivery.
         </p>
         <ul class="use-cases">


### PR DESCRIPTION
Packaged Web Publication is the name defined in the document. It is also possible that the Packaged Web Publication term will be deprecated in favor of EPUB4, but for now, we can be consistent in usage.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/dpub-pwp-ucr/pull/184.html" title="Last updated on Nov 15, 2018, 3:49 PM GMT (95957db)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/dpub-pwp-ucr/184/b418d14...95957db.html" title="Last updated on Nov 15, 2018, 3:49 PM GMT (95957db)">Diff</a>