### PR TITLE
removing affordances links

### DIFF
--- a/index.html
+++ b/index.html
@@ -563,8 +563,8 @@
           <li><a href="https://w3c.github.io/wpub/#cover">Cover &gt; Infoset Requirements</a></li>
           <li><a href="https://w3c.github.io/wpub/#table-of-contents">Table of Contents &gt; Manifest Expression</a></li>
           <li><a href="https://w3c.github.io/wpub/#extensibility-linked-records">Extensibility &gt; Linked Records</a></li>
-          <li><a href="https://w3c.github.io/wpub/#feature-publication-mode">Switch to Publication Mode</a></li>
-          <li><a href="https://w3c.github.io/wpub/#obtaining-manifest">Obtaining a manifest</a></li>
+<!--           <li><a href="https://w3c.github.io/wpub/#feature-publication-mode">Switch to Publication Mode</a></li>
+ -->          <li><a href="https://w3c.github.io/wpub/#obtaining-manifest">Obtaining a manifest</a></li>
         </ul>
       </section>
 
@@ -727,8 +727,8 @@
         <ul class="wpub-xref">
           <li><a href="https://w3c.github.io/wpub/#wp-table-of-contents">Table of Contents</a></li>
           <li><a href="https://w3c.github.io/wpub/#table-of-contents">Structural Properties &gt; Table of Contents</a></li>
-          <li><a href="https://w3c.github.io/wpub/#affordances">Table of Contents &gt; Affordances</a></li>
-        </ul>
+<!--           <li><a href="https://w3c.github.io/wpub/#affordances">Table of Contents &gt; Affordances</a></li>
+ -->        </ul>
 
         <p id="r_player-nav" class="req-set">
           For an audiobook Web Publication that provides a player interface, the user agent should provide the user a
@@ -750,8 +750,8 @@
           <li><a href="https://w3c.github.io/wpub/#audiobook-example">Audiobook</a></li>
           <li><a href="https://w3c.github.io/wpub/#wp-table-of-contents">Table of Contents</a></li>
           <li><a href="https://w3c.github.io/wpub/#table-of-contents">Structural Properties &gt; Table of Contents</a></li>
-          <li><a href="https://w3c.github.io/wpub/#affordances">Table of Contents &gt; Affordances</a></li>
-        </ul>
+<!--           <li><a href="https://w3c.github.io/wpub/#affordances">Table of Contents &gt; Affordances</a></li>
+ -->        </ul>
       </section>
 
       <section id="random-access">
@@ -950,8 +950,8 @@
           </li> -->
         </ul>
         <ul class="wpub-xref">
-          <li><a href="https://w3c.github.io/wpub/#example-65">Single-Document Publication &gt; Example 65</a></li>
-          <li><a href="https://w3c.github.io/wpub/#link-values">Values &gt; Link Values</a></li>
+<!--           <li><a href="https://w3c.github.io/wpub/#example-65">Single-Document Publication &gt; Example 65</a></li>
+ -->          <li><a href="https://w3c.github.io/wpub/#link-values">Values &gt; Link Values</a></li>
         </ul>
       </section>
 
@@ -975,8 +975,8 @@
         </ul>
         <ul class="wpub-xref">
           <li><a href="https://w3c.github.io/wpub/#privacy-policy">Privacy Policy &gt; Manifest Expression</a></li>
-          <li><a href="https://w3c.github.io/wpub/#feature-publication-mode">Switch to Publication Mode</a></li>
-        </ul>
+<!--           <li><a href="https://w3c.github.io/wpub/#feature-publication-mode">Switch to Publication Mode</a></li>
+ -->        </ul>
       </section>
     </section>
 
@@ -1027,7 +1027,7 @@
             <a href="https://w3c.github.io/wpub/#audiobook-example">Audiobook</a>
           </li>
           <li>
-            <a href="https://w3c.github.io/wpub/#feature-user-settings">User Settings</a>
+            <!-- <a href="https://w3c.github.io/wpub/#feature-user-settings">User Settings</a> -->
           </li>
         </ul>
       </section>
@@ -1067,8 +1067,8 @@
         </ul>
         <ul class="wpub-xref">
           <li><a href="https://w3c.github.io/wpub/#resource-categorization-properties">Resource Categorization Properties</a></li>
-          <li><a href="https://w3c.github.io/wpub/#layout">Layout</a></li>
-        </ul>
+<!--           <li><a href="https://w3c.github.io/wpub/#layout">Layout</a></li>
+ -->        </ul>
       </section>
 
       <section id="progression">
@@ -1098,11 +1098,11 @@
             doing her prep.
           </li>
         </ul>
-        <ul class="wpub-xref">
+<!--         <ul class="wpub-xref">
           <li><a href="https://w3c.github.io/wpub/#short-description-0">Reading State &gt; Short Description</a></li>
           <li><a href="https://w3c.github.io/wpub/#locators">Web Publication Locators</a></li>
         </ul>
-      </section>
+ -->      </section>
 
       <section id="reading-state">
         <h3>Reading State</h3>
@@ -1136,11 +1136,11 @@
         <ul class="wpub-xref">
           <li><a href="https://w3c.github.io/wpub/#page-list">Page List &gt; Infoset Requirements</a></li>
           <li><a href="https://w3c.github.io/wpub/#page-list">Page List &gt; Manifest Expression</a></li>
-          <li><a href="https://w3c.github.io/wpub/#feature-reading-order">Reading Order</a></li>
-          <li><a href="https://w3c.github.io/wpub/#resource-categorization-properties">Resource Categorization Properties</a></li>
+<!--           <li><a href="https://w3c.github.io/wpub/#feature-reading-order">Reading Order</a></li>
+ -->          <li><a href="https://w3c.github.io/wpub/#resource-categorization-properties">Resource Categorization Properties</a></li>
           <li><a href="https://w3c.github.io/wpub/#default-reading-order">Default Reading Order &gt; Manifest Expression</a></li>
-          <li><a href="https://w3c.github.io/wpub/#feature-pagination">Paginated Layout</a></li>
-        </ul>
+<!--           <li><a href="https://w3c.github.io/wpub/#feature-pagination">Paginated Layout</a></li>
+ -->        </ul>
       </section>
 
       <section id='movement'>
@@ -1198,11 +1198,11 @@
         <ul class="wpub-xref">
           <li><a href="https://w3c.github.io/wpub/#page-list">Page List &gt; Infoset Requirements</a></li>
           <li><a href="https://w3c.github.io/wpub/#page-list">Page List &gt; Manifest Expression</a></li>
-          <li><a href="https://w3c.github.io/wpub/#feature-reading-order">Reading Order</a></li>
-          <li><a href="https://w3c.github.io/wpub/#resource-categorization-properties">Resource Categorization Properties</a></li>
+<!--           <li><a href="https://w3c.github.io/wpub/#feature-reading-order">Reading Order</a></li>
+ -->          <li><a href="https://w3c.github.io/wpub/#resource-categorization-properties">Resource Categorization Properties</a></li>
           <li><a href="https://w3c.github.io/wpub/#default-reading-order">Default Reading Order &gt; Manifest Expression</a></li>
-          <li><a href="https://w3c.github.io/wpub/#feature-pagination">Paginated Layout</a></li>
-        </ul>
+<!--           <li><a href="https://w3c.github.io/wpub/#feature-pagination">Paginated Layout</a></li>
+ -->        </ul>
       </section>
 
       <section id='offline'>
@@ -1245,8 +1245,8 @@
         </ul>
         <ul class="wpub-xref">
           <li><a href="https://w3c.github.io/wpub/#scope">Scope</a></li>
-          <li><a href="https://w3c.github.io/wpub/#feature-offline-access">Offline Access</a></li>
-          <li><a href="https://w3c.github.io/wpub/#resource-list">Resource List</a></li>
+<!--           <li><a href="https://w3c.github.io/wpub/#feature-offline-access">Offline Access</a></li>
+ -->          <li><a href="https://w3c.github.io/wpub/#resource-list">Resource List</a></li>
         </ul>
 
         <p id="r_streaming" class="req-set">
@@ -1277,10 +1277,10 @@
         </ul>
           <ul class="wpub-xref">
           <li><a href="https://w3c.github.io/wpub/#scope">Scope</a></li>
-          <li><a href="https://w3c.github.io/wpub/#feature-offline-access">Offline Access</a></li>
-          <li><a href="https://w3c.github.io/wpub/#resource-list">Resource List</a></li>
-          <li><a href="https://w3c.github.io/wpub/#feature-user-settings">User Settings</a></li>
-          <li><a href="https://w3c.github.io/wpub/#audiobook-example">Audiobook</a></li>
+<!--           <li><a href="https://w3c.github.io/wpub/#feature-offline-access">Offline Access</a></li>
+ -->          <li><a href="https://w3c.github.io/wpub/#resource-list">Resource List</a></li>
+<!--           <li><a href="https://w3c.github.io/wpub/#feature-user-settings">User Settings</a></li>
+ -->          <li><a href="https://w3c.github.io/wpub/#audiobook-example">Audiobook</a></li>
         </ul>
       </section>
 
@@ -1624,10 +1624,10 @@
             service.
           </li>
         </ul>
-        <ul class="wpub-xref">
+<!--         <ul class="wpub-xref">
           <li><a href="https://w3c.github.io/wpub/#feature-publication-mode">Switch to publication mode</a></li>
         </ul>
-      </section>
+ -->      </section>
     </section>
 
     <!-- <section id='cross-ref'>


### PR DESCRIPTION
removing affordances links


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/dpub-pwp-ucr/pull/198.html" title="Last updated on Feb 14, 2019, 4:36 PM UTC (643d414)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/dpub-pwp-ucr/198/877cca4...643d414.html" title="Last updated on Feb 14, 2019, 4:36 PM UTC (643d414)">Diff</a>