### PR TITLE
Removing mentions of infoset requirements / manifest expression

### DIFF
--- a/index.html
+++ b/index.html
@@ -323,12 +323,12 @@
           </li>
         </ul>
         <ul class="wpub-xref">
-          <li><a href="https://w3c.github.io/wpub/#accessibility">Accessibility &gt; Infoset Requirements</a></li>
-          <li><a href="https://w3c.github.io/wpub/#language-and-dir">Language and Base Direction &gt; Infoset Requirements</a></li>
+          <li><a href="https://w3c.github.io/wpub/#accessibility">Accessibility</a></li>
+          <li><a href="https://w3c.github.io/wpub/#language-and-dir">Language and Base Direction</a></li>
           <li><a href="https://w3c.github.io/wpub/#manifest-specific-language-and-dir">Item-specific Language</a></li>
-          <li><a href="https://w3c.github.io/wpub/#reading-progression-direction">Reading Progression Direction &gt; Manifest Expression</a></li>
-          <li><a href="https://w3c.github.io/wpub/#accessibility-report">Accessibility Report &gt; Manifest Expression</a></li>
-          <li><a href="https://w3c.github.io/wpub/#privacy-policy">Privacy Policy &gt; Manifest Expression</a></li>
+          <li><a href="https://w3c.github.io/wpub/#reading-progression-direction">Reading Progression Direction</a></li>
+          <li><a href="https://w3c.github.io/wpub/#accessibility-report">Accessibility Report</a></li>
+          <li><a href="https://w3c.github.io/wpub/#privacy-policy">Privacy Policy</a></li>
         </ul>
       </section>
 
@@ -394,8 +394,8 @@
           <li><a href="https://w3c.github.io/wpub/#wp-bounds">Web Publication Bounds</a></li>
           <li><a href="https://w3c.github.io/wpub/#wp-resources">Resources</a></li>
           <li><a href="https://w3c.github.io/wpub/#wp-primary-entry-page">Primary Entry Page</a></li>
-          <li><a href="https://w3c.github.io/wpub/#address">Address &gt; Infoset Requirements</a></li>
-          <li><a href="https://w3c.github.io/wpub/#canonical-identifier">Canonical Identifier &gt; Infoset Requirements</a></li>
+          <li><a href="https://w3c.github.io/wpub/#address">Address</a></li>
+          <li><a href="https://w3c.github.io/wpub/#canonical-identifier">Canonical Identifier</a></li>
           <li><a href="https://w3c.github.io/wpub/#extensibility-linked-records">Linked Records</a></li>
           <li><a href="https://w3c.github.io/wpub/#obtaining-manifest">Obtaining a Manifest</a></li>
         </ul>
@@ -432,12 +432,12 @@
           <li><a href="https://w3c.github.io/wpub/#manifest-linking">Linking to a Manifest</a></li>
           <li><a href="https://w3c.github.io/wpub/#wp-table-of-contents">Table of Contents</a></li>
           <li><a href="https://w3c.github.io/wpub/#wp-pagelist">Page List</a></li>
-          <li><a href="https://w3c.github.io/wpub/#address">Address &gt; Infoset Requirements</a></li>
+          <li><a href="https://w3c.github.io/wpub/#address">Address</a></li>
           <li><a href="https://w3c.github.io/wpub/#resource-categorization-properties">Resource Categorization Properties</a></li>
-          <li><a href="https://w3c.github.io/wpub/#resource-list">Resource List &gt; Manifest Expression</a></li>
-          <li><a href="https://w3c.github.io/wpub/#cover">Cover &gt; Infoset Requirements</a></li>
-          <li><a href="https://w3c.github.io/wpub/#cover">Cover &gt; Manifest Expression</a></li>
-          <li><a href="https://w3c.github.io/wpub/#table-of-contents">Table of Contents &gt; Infoset Requirements</a></li>
+          <li><a href="https://w3c.github.io/wpub/#resource-list">Resource List</a></li>
+          <li><a href="https://w3c.github.io/wpub/#cover">Cover</a></li>
+          <li><a href="https://w3c.github.io/wpub/#cover">Cover</a></li>
+          <li><a href="https://w3c.github.io/wpub/#table-of-contents">Table of Contents</a></li>
         </ul>
 
         <p id="r_single" class="req-set cc-minimal">
@@ -467,7 +467,7 @@
           <li><a href="https://w3c.github.io/wpub/#manifest-pub-types">Publication Types</a></li>
           <li><a href="https://w3c.github.io/wpub/#wp-bounds">Web Publication Bounds</a></li>
           <li><a href="https://w3c.github.io/wpub/#wp-resources">Resources</a></li>
-          <li><a href="https://w3c.github.io/wpub/#address">Address &gt; Infoset Requirements</a></li>
+          <li><a href="https://w3c.github.io/wpub/#address">Address</a></li>
         </ul>
       </section>
 
@@ -552,16 +552,16 @@
         </ul>
         <ul class="wpub-xref">
           <li><a href="https://w3c.github.io/wpub/#manifest-linking">Linking to a Manifest</a></li>
-          <li><a href="https://w3c.github.io/wpub/#accessibility">Accessibility &gt; Infoset Requirements</a></li>
-          <li><a href="https://w3c.github.io/wpub/#creators">Creators &gt; Infoset Requirements </a></li>
-          <li><a href="https://w3c.github.io/wpub/#language-and-dir">Language and Base Direction &gt; Infoset Requirements</a></li>
+          <li><a href="https://w3c.github.io/wpub/#accessibility">Accessibility</a></li>
+          <li><a href="https://w3c.github.io/wpub/#creators">Creators </a></li>
+          <li><a href="https://w3c.github.io/wpub/#language-and-dir">Language and Base Direction</a></li>
           <li><a href="https://w3c.github.io/wpub/#manifest-specific-language-and-dir">Item-specific Language</a></li>
-          <li><a href="https://w3c.github.io/wpub/#wp-title">Title &gt; Infoset Requirements</a></li>
-          <li><a href="https://w3c.github.io/wpub/#links">Links &gt; Infoset Requirements</a></li>
-          <li><a href="https://w3c.github.io/wpub/#accessibility-report">Accessibility Report &gt; Manifest Expression</a></li>
-          <li><a href="https://w3c.github.io/wpub/#privacy-policy">Privacy Policy &gt; Manifest Expression</a></li>
-          <li><a href="https://w3c.github.io/wpub/#cover">Cover &gt; Infoset Requirements</a></li>
-          <li><a href="https://w3c.github.io/wpub/#table-of-contents">Table of Contents &gt; Manifest Expression</a></li>
+          <li><a href="https://w3c.github.io/wpub/#wp-title">Title</a></li>
+          <li><a href="https://w3c.github.io/wpub/#links">Links</a></li>
+          <li><a href="https://w3c.github.io/wpub/#accessibility-report">Accessibility Report</a></li>
+          <li><a href="https://w3c.github.io/wpub/#privacy-policy">Privacy Policy</a></li>
+          <li><a href="https://w3c.github.io/wpub/#cover">Cover</a></li>
+          <li><a href="https://w3c.github.io/wpub/#table-of-contents">Table of Contents</a></li>
           <li><a href="https://w3c.github.io/wpub/#extensibility-linked-records">Extensibility &gt; Linked Records</a></li>
           <li><a href="https://w3c.github.io/wpub/#feature-publication-mode">Switch to Publication Mode</a></li>
           <li><a href="https://w3c.github.io/wpub/#obtaining-manifest">Obtaining a manifest</a></li>
@@ -648,11 +648,11 @@
         <ul class="wpub-xref">
           <li><a href="https://w3c.github.io/wpub/#manifest-embedding">Embedding a Manifest</a></li>
           <li><a href="https://w3c.github.io/wpub/#manifest-linking">Linking to a Manifest</a></li>
-          <li><a href="https://w3c.github.io/wpub/#address">Address &gt; Infoset Requirements</a></li>
+          <li><a href="https://w3c.github.io/wpub/#address">Address</a></li>
           <li><a href="https://w3c.github.io/wpub/#resource-categorization-properties">Resource Categorization Properties</a></li>
-          <li><a href="https://w3c.github.io/wpub/#links">Links &gt; Infoset Requirements</a></li>
-          <li><a href="https://w3c.github.io/wpub/#cover">Cover &gt; Infoset Requirements</a></li>
-          <li><a href="https://w3c.github.io/wpub/#table-of-contents">Table of Contents &gt; Infoset Requirements</a></li>
+          <li><a href="https://w3c.github.io/wpub/#links">Links</a></li>
+          <li><a href="https://w3c.github.io/wpub/#cover">Cover</a></li>
+          <li><a href="https://w3c.github.io/wpub/#table-of-contents">Table of Contents</a></li>
         </ul>
       </section>
 
@@ -689,8 +689,8 @@
         <ul class="wpub-xref">
           <li><a href="https://w3c.github.io/wpub/#wp-table-of-contents">Table of Contents</a></li>
           <li><a href="https://w3c.github.io/wpub/#wp-pagelist">Page List</a></li>
-          <li><a href="https://w3c.github.io/wpub/#default-reading-order">Default Reading Order &gt; Manifest Expression</a></li>
-          <li><a href="https://w3c.github.io/wpub/#table-of-contents">Table of Contents &gt; Infoset Requirements</a></li>
+          <li><a href="https://w3c.github.io/wpub/#default-reading-order">Default Reading Order</a></li>
+          <li><a href="https://w3c.github.io/wpub/#table-of-contents">Table of Contents</a></li>
         </ul>
       </section>
 
@@ -819,9 +819,9 @@
           </li>
         </ul>
         <ul class="wpub-xref">
-          <li><a href="https://w3c.github.io/wpub/#default-reading-order">Default Reading Order &gt; Infoset Requirements</a></li>
-          <li><a href="https://w3c.github.io/wpub/#default-reading-order">Default Reading Order &gt; Manifest Expression</a></li>
-          <li><a href="https://w3c.github.io/wpub/#table-of-contents">Table of Contents &gt; Infoset Requirements</a></li>
+          <li><a href="https://w3c.github.io/wpub/#default-reading-order">Default Reading Order</a></li>
+          <li><a href="https://w3c.github.io/wpub/#default-reading-order">Default Reading Order</a></li>
+          <li><a href="https://w3c.github.io/wpub/#table-of-contents">Table of Contents</a></li>
         </ul>
 
         <p id="r_print-page" class="req-set">
@@ -842,9 +842,9 @@
         <ul class="wpub-xref">
           <li><a href="https://w3c.github.io/wpub/#wp-table-of-contents">Table of Contents</a></li>
           <li><a href="https://w3c.github.io/wpub/#wp-pagelist">Page List</a></li>
-          <li><a href="https://w3c.github.io/wpub/#table-of-contents">Table of Contents &gt; Infoset Requirements</a></li>
-          <li><a href="https://w3c.github.io/wpub/#page-list">Page List &gt; Manifest Expression</a></li>
-          <li><a href="https://w3c.github.io/wpub/#page-list">Page List &gt; Infoset Requirements</a></li>
+          <li><a href="https://w3c.github.io/wpub/#table-of-contents">Table of Contents</a></li>
+          <li><a href="https://w3c.github.io/wpub/#page-list">Page List</a></li>
+          <li><a href="https://w3c.github.io/wpub/#page-list">Page List</a></li>
         </ul>
       </section>
 
@@ -880,7 +880,7 @@
         <ul class="wpub-xref">
           <li><a href="https://w3c.github.io/wpub/#manifest-pub-types">Publication Types</a></li>
           <li><a href="https://w3c.github.io/wpub/#wp-bounds">Web Publication Bounds</a></li>
-          <li><a href="https://w3c.github.io/wpub/#links">Links &gt; Infoset Requirements</a></li>
+          <li><a href="https://w3c.github.io/wpub/#links">Links</a></li>
         </ul>
       </section>
 
@@ -908,8 +908,8 @@
           </li>
         </ul>
         <ul class="wpub-xref">
-          <li><a href="https://w3c.github.io/wpub/#links">Links &gt; Infoset Requirements</a></li>
-          <li><a href="https://w3c.github.io/wpub/#resource-list">Resource List &gt; Infoset Requirements</a></li>
+          <li><a href="https://w3c.github.io/wpub/#links">Links</a></li>
+          <li><a href="https://w3c.github.io/wpub/#resource-list">Resource List</a></li>
         </ul>
       </section>
 
@@ -974,7 +974,7 @@
           </li>
         </ul>
         <ul class="wpub-xref">
-          <li><a href="https://w3c.github.io/wpub/#privacy-policy">Privacy Policy &gt; Manifest Expression</a></li>
+          <li><a href="https://w3c.github.io/wpub/#privacy-policy">Privacy Policy</a></li>
           <li><a href="https://w3c.github.io/wpub/#feature-publication-mode">Switch to Publication Mode</a></li>
         </ul>
       </section>
@@ -1134,11 +1134,11 @@
           </li>
         </ul>
         <ul class="wpub-xref">
-          <li><a href="https://w3c.github.io/wpub/#page-list">Page List &gt; Infoset Requirements</a></li>
-          <li><a href="https://w3c.github.io/wpub/#page-list">Page List &gt; Manifest Expression</a></li>
+          <li><a href="https://w3c.github.io/wpub/#page-list">Page List</a></li>
+          <li><a href="https://w3c.github.io/wpub/#page-list">Page List</a></li>
           <li><a href="https://w3c.github.io/wpub/#feature-reading-order">Reading Order</a></li>
           <li><a href="https://w3c.github.io/wpub/#resource-categorization-properties">Resource Categorization Properties</a></li>
-          <li><a href="https://w3c.github.io/wpub/#default-reading-order">Default Reading Order &gt; Manifest Expression</a></li>
+          <li><a href="https://w3c.github.io/wpub/#default-reading-order">Default Reading Order</a></li>
           <li><a href="https://w3c.github.io/wpub/#feature-pagination">Paginated Layout</a></li>
         </ul>
       </section>
@@ -1196,11 +1196,11 @@
           </li>
         </ul>
         <ul class="wpub-xref">
-          <li><a href="https://w3c.github.io/wpub/#page-list">Page List &gt; Infoset Requirements</a></li>
-          <li><a href="https://w3c.github.io/wpub/#page-list">Page List &gt; Manifest Expression</a></li>
+          <li><a href="https://w3c.github.io/wpub/#page-list">Page List</a></li>
+          <li><a href="https://w3c.github.io/wpub/#page-list">Page List</a></li>
           <li><a href="https://w3c.github.io/wpub/#feature-reading-order">Reading Order</a></li>
           <li><a href="https://w3c.github.io/wpub/#resource-categorization-properties">Resource Categorization Properties</a></li>
-          <li><a href="https://w3c.github.io/wpub/#default-reading-order">Default Reading Order &gt; Manifest Expression</a></li>
+          <li><a href="https://w3c.github.io/wpub/#default-reading-order">Default Reading Order</a></li>
           <li><a href="https://w3c.github.io/wpub/#feature-pagination">Paginated Layout</a></li>
         </ul>
       </section>
@@ -1312,7 +1312,7 @@
           </li>
         </ul>
         <ul class="wpub-xref">
-          <li><a href="https://w3c.github.io/wpub/#language-and-dir">Language and Base Direction &gt; Infoset Requirements</a></li>
+          <li><a href="https://w3c.github.io/wpub/#language-and-dir">Language and Base Direction</a></li>
         </ul>
       </section>
 
@@ -1431,7 +1431,7 @@
         </ul>
         <ul class="wpub-xref">
           <li><a href="https://w3c.github.io/wpub/#wp-bounds">Web Publication Bounds</a></li>
-          <li><a href="https://w3c.github.io/wpub/#default-reading-order">Default Reading Order &gt; Infoset Requirements</a></li>
+          <li><a href="https://w3c.github.io/wpub/#default-reading-order">Default Reading Order</a></li>
         </ul>
       </section>
 
@@ -1522,7 +1522,7 @@
           </li>
         </ul>
         <ul class="wpub-xref">
-          <li><a href="https://w3c.github.io/wpub/#creators">Creators &gt; Infoset Requirements</a></li>
+          <li><a href="https://w3c.github.io/wpub/#creators">Creators</a></li>
           <li><a href="https://w3c.github.io/wpub/#extensibility-linked-records">Extensibility &gt; Linked records</a></li>
         </ul>
       </section>
@@ -1543,7 +1543,7 @@
           </li>
         </ul>
         <ul class="wpub-xref">
-          <li><a href="https://w3c.github.io/wpub/#creators">Creators &gt; Infoset Requirements</a></li>
+          <li><a href="https://w3c.github.io/wpub/#creators">Creators</a></li>
         </ul>
       </section>
 
@@ -1586,7 +1586,7 @@
         </ul>
         <ul class="wpub-xref">
           <li><a href="https://w3c.github.io/wpub/#extensibility-linked-records">Extensibility &gt; Linked records</a></li>
-          <li><a href="https://w3c.github.io/wpub/#wp-title">Title &gt; Infoset Requirements  </a></li>
+          <li><a href="https://w3c.github.io/wpub/#wp-title">Title  </a></li>
         </ul>
 
         <p id="r_component-change" class="req-set">


### PR DESCRIPTION
Per Ivan's email, I agree that this labeling is unnecessary when pointing the reader to the WPUB spec. Have removed all instances and retained the links


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/dpub-pwp-ucr/pull/199.html" title="Last updated on Feb 15, 2019, 1:45 PM UTC (4a672e9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/dpub-pwp-ucr/199/8adf35b...4a672e9.html" title="Last updated on Feb 15, 2019, 1:45 PM UTC (4a672e9)">Diff</a>