### PR TITLE
Removing style note from UCR

### DIFF
--- a/index.html
+++ b/index.html
@@ -1150,21 +1150,6 @@
         </ul>
       </section>
 
-      <section id="style">
-        <h3>Style</h3>
-        <div class="note">
-          <p>
-            The requirements related to style may be sufficiently addressed in 5.2 personalization, req: "The user
-            must have the possibility to personalize his or her reading experience. This may include, for example,
-            controlling such features as font size, choice of fonts, background and foreground color, tone of audio,
-            etc"
-          </p>
-        </div>
-        <!--<ul class="use-cases">
-          <li></li>
-        </ul>-->
-      </section>
-
       <section id="layout">
         <h3>Layout</h3>
         <p id="r_separate-const-resources" class="req-set">


### PR DESCRIPTION
Removing style note from UCR


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/dpub-pwp-ucr/pull/222.html" title="Last updated on Jun 24, 2019, 5:35 PM UTC (84efac3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/dpub-pwp-ucr/222/3f35f9d...84efac3.html" title="Last updated on Jun 24, 2019, 5:35 PM UTC (84efac3)">Diff</a>