### PR TITLE
Links updated 20190626

### DIFF
--- a/index.html
+++ b/index.html
@@ -1520,6 +1520,11 @@
             off.
           </li>
         </ul>
+
+</section>
+<section id="document-archiving-ua">
+        <h3>Archiving</h3>
+
         <p>
           We take for granted the relative durability of print artifacts, many of which have survived with little more
           than benign neglect. In contrast, digital documents are unlikely to persist without more active interventions,

--- a/index.html
+++ b/index.html
@@ -408,12 +408,12 @@
         <ul class="wpub-xref">
           <li><a href="https://www.w3.org/TR/wpub/#wp-bounds">Web Publication Bounds</a></li>
           <li><a href="https://www.w3.org/TR/wpub/#wp-resources">Resources</a></li>
-          <li><a href="https://www.w3.org/TR/wpub/#wp-primary-entry-page">Primary Entry Page</a></li>
+          <li><a href="https://www.w3.org/TR/wpub/#primary-entry-page">Primary Entry Page</a></li>
           <li><a href="https://www.w3.org/TR/wpub/#address">Address</a></li>
           <li><a href="https://www.w3.org/TR/wpub/#canonical-identifier">Canonical Identifier</a></li>
           <li><a href="https://www.w3.org/TR/wpub/#extensibility-linked-records">Linked Records</a></li>
-          <li><a href="https://www.w3.org/TR/wpub/#obtaining-manifest">Obtaining a Manifest</a></li>
-          <li><a href="https://www.w3.org/TR/wpub/#manifest-pub-types">Publication Types</a></li>
+          <li><a href="https://www.w3.org/TR/wpub/#wp-obtaining-manifest">Obtaining a Manifest</a></li>
+          <li><a href="https://www.w3.org/TR/wpub/#publication-types">Publication Types</a></li>
         </ul>
 
         <p id="r_identify-const-resources" class="req-set">
@@ -443,14 +443,12 @@
           </li>
         </ul>
         <ul class="wpub-xref">
-          <li><a href="https://www.w3.org/TR/wpub/#manifest-embedding">Embedding a Manifest</a></li>
-          <li><a href="https://www.w3.org/TR/wpub/#manifest-linking">Linking to a Manifest</a></li>
-          <li><a href="https://www.w3.org/TR/wpub/#wp-table-of-contents">Table of Contents</a></li>
-          <li><a href="https://www.w3.org/TR/wpub/#wp-pagelist">Page List</a></li>
+          <li><a href="https://www.w3.org/TR/wpub/#manifest-embed">Embedding a Manifest</a></li>
+          <li><a href="https://www.w3.org/TR/wpub/#manifest-link">Linking to a Manifest</a></li>
+          <li><a href="https://www.w3.org/TR/wpub/#pagelist">Page List</a></li>
           <li><a href="https://www.w3.org/TR/wpub/#address">Address</a></li>
           <li><a href="https://www.w3.org/TR/wpub/#resource-categorization-properties">Resource Categorization Properties</a></li>
           <li><a href="https://www.w3.org/TR/wpub/#resource-list">Resource List</a></li>
-          <li><a href="https://www.w3.org/TR/wpub/#cover">Cover</a></li>
           <li><a href="https://www.w3.org/TR/wpub/#cover">Cover</a></li>
           <li><a href="https://www.w3.org/TR/wpub/#table-of-contents">Table of Contents</a></li>
         </ul>
@@ -536,7 +534,7 @@
           </li>
         </ul>
         <ul class="wpub-xref">
-          <li><a href="https://www.w3.org/TR/wpub/#manifest-linking">Linking to a Manifest</a></li>
+          <li><a href="https://www.w3.org/TR/wpub/#manifest-link">Linking to a Manifest</a></li>
           <li><a href="https://www.w3.org/TR/wpub/#accessibility">Accessibility</a></li>
           <li><a href="https://www.w3.org/TR/wpub/#creators">Creators </a></li>
           <li><a href="https://www.w3.org/TR/wpub/#language-and-dir">Language and Base Direction</a></li>
@@ -547,9 +545,9 @@
           <li><a href="https://www.w3.org/TR/wpub/#privacy-policy">Privacy Policy</a></li>
           <li><a href="https://www.w3.org/TR/wpub/#cover">Cover</a></li>
           <li><a href="https://www.w3.org/TR/wpub/#table-of-contents">Table of Contents</a></li>
-          <li><a href="https://www.w3.org/TR/wpub/#extensibility-linked-records">Extensibility &gt; Linked Records</a></li>
+          <li><a href="https://www.w3.org/TR/wpub/#extensibility-linked-records">Linked records</a></li>
           <!--<li><a href="https://www.w3.org/TR/wpub/#feature-publication-mode">Switch to Publication Mode</a></li>-->
-          <li><a href="https://www.w3.org/TR/wpub/#obtaining-manifest">Obtaining a manifest</a></li>
+          <li><a href="https://www.w3.org/TR/wpub/#wp-obtaining-manifest">Obtaining a manifest</a></li>
         </ul>
       </section>
 
@@ -631,8 +629,8 @@
           </li>
         </ul>
         <ul class="wpub-xref">
-          <li><a href="https://www.w3.org/TR/wpub/#manifest-embedding">Embedding a Manifest</a></li>
-          <li><a href="https://www.w3.org/TR/wpub/#manifest-linking">Linking to a Manifest</a></li>
+          <li><a href="https://www.w3.org/TR/wpub/#manifest-embed">Embedding a Manifest</a></li>
+          <li><a href="https://www.w3.org/TR/wpub/#manifest-link">Linking to a Manifest</a></li>
           <li><a href="https://www.w3.org/TR/wpub/#address">Address</a></li>
           <li><a href="https://www.w3.org/TR/wpub/#resource-categorization-properties">Resource Categorization Properties</a></li>
           <li><a href="https://www.w3.org/TR/wpub/#links">Links</a></li>
@@ -672,8 +670,7 @@
           </li>
         </ul>
         <ul class="wpub-xref">
-          <li><a href="https://www.w3.org/TR/wpub/#wp-table-of-contents">Table of Contents</a></li>
-          <li><a href="https://www.w3.org/TR/wpub/#wp-pagelist">Page List</a></li>
+          <li><a href="https://www.w3.org/TR/wpub/#pagelist">Page List</a></li>
           <li><a href="https://www.w3.org/TR/wpub/#default-reading-order">Default Reading Order</a></li>
           <li><a href="https://www.w3.org/TR/wpub/#table-of-contents">Table of Contents</a></li>
         </ul>
@@ -710,9 +707,7 @@
           </li>
         </ul>
         <ul class="wpub-xref">
-          <li><a href="https://www.w3.org/TR/wpub/#wp-table-of-contents">Table of Contents</a></li>
-          <li><a href="https://www.w3.org/TR/wpub/#table-of-contents">Structural Properties &gt; Table of Contents</a></li>
-          <!--<li><a href="https://www.w3.org/TR/wpub/#affordances">Table of Contents &gt; Affordances</a></li>-->
+          <li><a href="https://www.w3.org/TR/wpub/#table-of-contents">Table of Contents</a></li>
         </ul>
 
         <p id="r_player-nav" class="req-set">
@@ -735,9 +730,8 @@
           </li>
         </ul>
         <ul class="wpub-xref">
-          <li><a href="https://www.w3.org/TR/wpub/#audiobook">Audiobook</a></li>
-          <li><a href="https://www.w3.org/TR/wpub/#wp-table-of-contents">Table of Contents</a></li>
-          <li><a href="https://www.w3.org/TR/wpub/#table-of-contents">Structural Properties &gt; Table of Contents</a></li>
+          <li><a href="https://www.w3.org/TR/audiobooks/">Audiobook</a></li>
+          <li><a href="https://www.w3.org/TR/wpub/#table-of-contents">Table of Contents</a></li>
           <!--<li><a href="https://www.w3.org/TR/wpub/#affordances">Table of Contents &gt; Affordances</a></li>-->
         </ul>
       </section>
@@ -808,7 +802,6 @@
         </ul>
         <ul class="wpub-xref">
           <li><a href="https://www.w3.org/TR/wpub/#default-reading-order">Default Reading Order</a></li>
-          <li><a href="https://www.w3.org/TR/wpub/#default-reading-order">Default Reading Order</a></li>
           <li><a href="https://www.w3.org/TR/wpub/#table-of-contents">Table of Contents</a></li>
         </ul>
 
@@ -828,10 +821,7 @@
           </li>
         </ul>
         <ul class="wpub-xref">
-          <li><a href="https://www.w3.org/TR/wpub/#wp-table-of-contents">Table of Contents</a></li>
-          <li><a href="https://www.w3.org/TR/wpub/#wp-pagelist">Page List</a></li>
           <li><a href="https://www.w3.org/TR/wpub/#table-of-contents">Table of Contents</a></li>
-          <li><a href="https://www.w3.org/TR/wpub/#page-list">Page List</a></li>
           <li><a href="https://www.w3.org/TR/wpub/#page-list">Page List</a></li>
         </ul>
       </section>
@@ -866,7 +856,7 @@
           </li>
         </ul>
         <ul class="wpub-xref">
-          <li><a href="https://www.w3.org/TR/wpub/#manifest-pub-types">Publication Types</a></li>
+          <li><a href="https://www.w3.org/TR/wpub/#publication-types">Publication Types</a></li>
           <li><a href="https://www.w3.org/TR/wpub/#wp-bounds">Web Publication Bounds</a></li>
           <li><a href="https://www.w3.org/TR/wpub/#links">Links</a></li>
         </ul>
@@ -939,7 +929,7 @@
         </ul>
         <ul class="wpub-xref">
           <!--<li><a href="https://www.w3.org/TR/wpub/#example-65">Single-Document Publication &gt; Example 65</a></li>-->
-          <li><a href="https://www.w3.org/TR/wpub/#link-values">Values &gt; Link Values</a></li>
+          <li><a href="https://www.w3.org/TR/wpub/#resource-list">Resource List</a></li>
         </ul>
       </section>
 
@@ -1006,6 +996,7 @@
         </ul>
         <ul class="wpub-xref">
           <li><a href="https://www.w3.org/TR/wpub/#links">Links</a></li>
+          <li><a href="https://www.w3.org/TR/wpub/#webpub">Web Publications</a></li>
         </ul>
 
         <p id="r_pwp-links" class="req-set">
@@ -1047,7 +1038,7 @@
         </ul>
         <ul class="wpub-xref">
           <li><a href="https://www.w3.org/TR/wpub/#creators">Creators</a></li>
-          <li><a href="https://www.w3.org/TR/wpub/#extensibility-linked-records">Extensibility &gt; Linked records</a></li>
+          <li><a href="https://www.w3.org/TR/wpub/#extensibility-linked-records">Linked records</a></li>
         </ul>
 
         <p id="r_check-integrity" class="req-set">
@@ -1110,7 +1101,7 @@
         </ul>
         <ul class="wpub-xref">
           <li>
-            <a href="https://www.w3.org/TR/wpub/#audiobook">Audiobook</a>
+            <a href="https://www.w3.org/TR/audiobooks/">Audiobook</a>
           </li>
         </ul>
         <p id="r_skip-by-increment" class="req-set">
@@ -1137,6 +1128,11 @@
             introductory content and content that she already has a firm  understanding of.
           </li>
         </ul>
+        <ul class="wpub-xref">
+          <li>
+            <a href="https://www.w3.org/TR/audiobooks/">Audiobook</a>
+          </li>
+        </ul>
         <p id="r_duration" class="req-set">
           If a Web Publication contains time-based media, a user should be able to understand the duration of the media,
           both in its entirety and of its constituent parts.
@@ -1147,6 +1143,12 @@
             next video plays. He is able to view the duration of the current video in the player interface of the user
             agent.
           </li>
+        </ul>
+        <ul class="wpub-xref">
+          <li>
+            <a href="https://www.w3.org/TR/audiobooks/">Audiobook</a>
+          </li>
+          <li><a href="https://www.w3.org/TR/wpub/#duration">Duration</a></li>
         </ul>
       </section>
 
@@ -1363,7 +1365,7 @@
           <!--<li><a href="https://www.w3.org/TR/wpub/#feature-offline-access">Offline Access</a></li>-->
           <li><a href="https://www.w3.org/TR/wpub/#resource-list">Resource List</a></li>
           <!--<li><a href="https://www.w3.org/TR/wpub/#feature-user-settings">User Settings</a></li>-->
-          <li><a href="https://www.w3.org/TR/wpub/#audiobook">Audiobook</a></li>
+          <li><a href="https://www.w3.org/TR/audiobooks/">Audiobook</a></li>
         </ul>
       </section>
 
@@ -1396,6 +1398,7 @@
         </ul>
         <ul class="wpub-xref">
           <li><a href="https://www.w3.org/TR/wpub/#language-and-dir">Language and Base Direction</a></li>
+          <li><a href="https://www.w3.org/TR/wpub/#accessibility">Accessibility</a></li>
         </ul>
       </section>
 
@@ -1445,8 +1448,8 @@
         </ul>
         <ul class="wpub-xref">
           <li><a href="https://www.w3.org/TR/wpub/#wp-resources">Resources</a></li>
-          <li><a href="https://www.w3.org/TR/wpub/#address">Descriptive Properties > Address</a></li>
-          <li><a href="https://www.w3.org/TR/wpub/#audiobook">Audiobook</a></li>
+          <li><a href="https://www.w3.org/TR/wpub/#address">Address</a></li>
+          <li><a href="https://www.w3.org/TR/audiobooks/">Audiobook</a></li>
         </ul>
       </section>
 
@@ -1494,7 +1497,7 @@
           </li>
         </ul>
         <ul class="wpub-xref">
-          <li><a href="https://www.w3.org/TR/wpub/#extensibility-linked-records">Extensibility &gt; Linked records</a></li>
+          <li><a href="https://www.w3.org/TR/wpub/#extensibility-linked-records">Linked records</a></li>
         </ul>
 
         <p id="r_pwp-process" class="req-set">
@@ -1517,7 +1520,6 @@
             off.
           </li>
         </ul>
-
         <p>
           We take for granted the relative durability of print artifacts, many of which have survived with little more
           than benign neglect. In contrast, digital documents are unlikely to persist without more active interventions,
@@ -1554,7 +1556,7 @@
           </li>
         </ul>
         <ul class="wpub-xref">
-          <li><a href="https://www.w3.org/TR/wpub/#extensibility-linked-records">Extensibility &gt; Linked records</a></li>
+          <li><a href="https://www.w3.org/TR/wpub/#extensibility-linked-records">Linked records</a></li>
           <li><a href="https://www.w3.org/TR/wpub/#wp-title">Title  </a></li>
         </ul>
 


### PR DESCRIPTION
Hi @atyposh , I have updated the links, but I also noted an orphaned paragraph related to archiving. Why did we remove the archiving section again? At any rate, I have added it back in with this PR, but let me know if there is somewhere else we should put this paragraph or whether we should remove it. I think it is a good paragraph to have since it is informative and relates to a unique situation in publishing.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/dpub-pwp-ucr/pull/224.html" title="Last updated on Jun 26, 2019, 4:44 PM UTC (ae85472)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/dpub-pwp-ucr/224/3a33589...ae85472.html" title="Last updated on Jun 26, 2019, 4:44 PM UTC (ae85472)">Diff</a>